### PR TITLE
feat(music): Implement code from POC

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,2 +1,5 @@
 export { Note } from './src/Note'
+export { CustomAccord } from './src/CustomAccord'
 export { Partition } from './src/Partition'
+export { NoteEnum } from './src/NoteEnum'
+export { JSONPartition } from './src/JSONPartition'

--- a/src/CustomAccord.ts
+++ b/src/CustomAccord.ts
@@ -1,0 +1,13 @@
+import {Note} from "./Note";
+
+class CustomAccord {
+    constructor(
+        public notes: Note[],
+    ) {}
+
+    // TODO: Implement Play method
+    // play() {
+    // }
+}
+
+export { CustomAccord }

--- a/src/CustomAccord.ts
+++ b/src/CustomAccord.ts
@@ -1,13 +1,12 @@
 import {Note} from "./Note";
 
 class CustomAccord {
+    /**
+     * @param {Note[]} notes - The notes that will be played simultaneously.
+     */
     constructor(
         public notes: Note[],
     ) {}
-
-    // TODO: Implement Play method
-    // play() {
-    // }
 }
 
 export { CustomAccord }

--- a/src/JSONPartition.ts
+++ b/src/JSONPartition.ts
@@ -1,0 +1,33 @@
+import {Partition} from "./Partition";
+import {NoteEnum} from "./NoteEnum";
+import {CustomAccord} from "./CustomAccord";
+import {Note} from "./Note";
+
+interface JSONNote {
+	note: string,
+	duration: number,
+	octave: number,
+}
+
+class JSONPartition extends Partition {
+	constructor(
+		public json: JSONNote[][],
+		public oscillator: OscillatorType = 'sine',
+		public audioContext: AudioContext,
+	) {
+		let jsonAccords: CustomAccord[] = [];
+		for (const accord of json) {
+			let notes = [];
+			for (const note of accord) {
+				// @ts-ignore
+				notes.push(new Note(NoteEnum[note.note], note.octave, note.duration));
+			}
+			jsonAccords.push(new CustomAccord(notes));
+		}
+
+		super(jsonAccords, oscillator, audioContext);
+	}
+
+}
+
+export { JSONPartition }

--- a/src/JSONPartition.ts
+++ b/src/JSONPartition.ts
@@ -10,6 +10,12 @@ interface JSONNote {
 }
 
 class JSONPartition extends Partition {
+
+	/**
+	 * @param {JSONNote[][]} json - The JSON that will be parsed into a partition.
+	 * @param {OscillatorType} oscillator - The oscillator type that will be used to play the partition.
+	 * @param {AudioContext} audioContext - The audio context that will be used to play the partition.
+	 */
 	constructor(
 		public json: JSONNote[][],
 		public oscillator: OscillatorType = 'sine',

--- a/src/Note.ts
+++ b/src/Note.ts
@@ -6,7 +6,7 @@ class Note {
 	/**
 	 * @param {NoteEnum} note
 	 * @param {number} octave - 0 to 8
-	 * @param {number} duration How many beats will this note last.
+	 * @param {number} duration How long the note will be played in seconds. (you most likely want to stay under 1 second)
 	 */
 	constructor(
 		public note: NoteEnum,

--- a/src/Note.ts
+++ b/src/Note.ts
@@ -1,31 +1,38 @@
+import {NoteEnum} from "./NoteEnum";
+
 class Note {
-	constructor(public frequency: number) {}
+	private pitch: number;
 
-	private context = new AudioContext()
-
-	private createOscillator() {
-		const oscillator = this.context.createOscillator()
-		oscillator.type = 'sine'
-		oscillator.frequency.value = this.frequency
-		return oscillator
+	/**
+	 * @param {NoteEnum} note
+	 * @param {number} octave - 0 to 8
+	 * @param {number} duration How many beats will this note last.
+	 */
+	constructor(
+		public note: NoteEnum,
+		public octave: number,
+		public duration: number,
+	) {
+		this.pitch = this.getPitch();
 	}
 
-	private createGain() {
-		const gain = this.context.createGain()
-		gain.gain.value = 0.1
-		return gain
+	getPitch() {
+		let step = this.note.valueOf();
+		let power = Math.pow(2, (this.octave * 12 + step - 57)/12);
+		return 440 * power;
 	}
 
-	play() {
-		const oscillator = this.createOscillator()
-		const gain = this.createGain()
-
-		oscillator.connect(gain)
-		gain.connect(this.context.destination)
-
-		oscillator.start()
-		oscillator.stop(this.context.currentTime + 1)
-	}
+	// TODO: Implement Play method
+	// play() {
+	// 	const oscillator = this.createOscillator()
+	// 	const gain = this.createGain()
+	//
+	// 	oscillator.connect(gain)
+	// 	gain.connect(this.context.destination)
+	//
+	// 	oscillator.start()
+	// 	oscillator.stop(this.context.currentTime + 1)
+	// }
 }
 
 export { Note }

--- a/src/Note.ts
+++ b/src/Note.ts
@@ -16,23 +16,14 @@ class Note {
 		this.pitch = this.getPitch();
 	}
 
+	/**
+	 * @returns {number} The pitch of the note in Hz.
+	 */
 	getPitch() {
 		let step = this.note.valueOf();
 		let power = Math.pow(2, (this.octave * 12 + step - 57)/12);
 		return 440 * power;
 	}
-
-	// TODO: Implement Play method
-	// play() {
-	// 	const oscillator = this.createOscillator()
-	// 	const gain = this.createGain()
-	//
-	// 	oscillator.connect(gain)
-	// 	gain.connect(this.context.destination)
-	//
-	// 	oscillator.start()
-	// 	oscillator.stop(this.context.currentTime + 1)
-	// }
 }
 
 export { Note }

--- a/src/NoteEnum.ts
+++ b/src/NoteEnum.ts
@@ -1,0 +1,16 @@
+enum NoteEnum {
+    C = 0,
+    CSharp = 1,
+    D = 2,
+    DSharp = 3,
+    E = 4,
+    F = 5,
+    FSharp = 6,
+    G = 7,
+    GSharp = 8,
+    A = 9,
+    ASharp = 10,
+    B = 11
+}
+
+export { NoteEnum }

--- a/src/NoteEnum.ts
+++ b/src/NoteEnum.ts
@@ -1,3 +1,6 @@
+/**
+ * NoteEnum is a list of all the notes in the chromatic scale.
+ */
 enum NoteEnum {
     C = 0,
     CSharp = 1,

--- a/src/Partition.ts
+++ b/src/Partition.ts
@@ -33,16 +33,16 @@ class Partition {
 			let oscillators = this.getOscillatorNodesFromAccord(accord)
 
 			if (oscillators[0]) {
-				oscillators.forEach(({oscillatorNode}) => oscillatorNode.start(this.audioContext.currentTime));
+				oscillators.forEach(({oscillatorNode, noteDuration}) => {
+					oscillatorNode.start(this.audioContext.currentTime)
 
-				setTimeout(() => {
-					oscillators.forEach(({oscillatorNode}) => {
+					setTimeout(() => {
 						oscillatorNode.stop(0);
 						oscillatorNode.disconnect();
-					});
 
-					resolve();
-				}, oscillators[0].noteDuration * 1000);
+						resolve();
+					}, noteDuration * 1000);
+				});
 			}
 		});
 	}
@@ -52,7 +52,7 @@ class Partition {
 		let oscillatorNode: OscillatorNode
 
 		return accord.notes.map((note) => {
-			const noteDuration: number = note.duration * 0.18
+			const noteDuration: number = note.duration
 
 			gainNode = this.audioContext.createGain()
 			gainNode.connect(this.audioContext.destination)

--- a/src/Partition.ts
+++ b/src/Partition.ts
@@ -1,17 +1,57 @@
-import { Note } from "./Note"
+import {CustomAccord} from "./CustomAccord"
 
 class Partition {
-	constructor(private notes: Note[]) {}
+	constructor(
+		public accords: CustomAccord[],
+		public oscillator: OscillatorType = 'sine',
+		public audioContext: AudioContext,
+	) {}
 
-	private playNoteWithDelay(note: Note, delay: number) {
-		setTimeout(() => note.play(), delay)
+	public async playPartition() {
+		for (const accord of this.accords) {
+			await this.playAccord(accord)
+		}
 	}
 
-	play() {
-		let delay = 0
-		this.notes.forEach((note) => {
-			this.playNoteWithDelay(note, delay)
-			delay += 1000
+	public async playAccord(accord: CustomAccord) {
+		return new Promise<void>((resolve) => {
+			let oscillators = this.getOscillatorNodesFromAccord(accord)
+
+			if (oscillators[0]) {
+				oscillators.forEach(({oscillatorNode}) => oscillatorNode.start(this.audioContext.currentTime));
+
+				setTimeout(() => {
+					oscillators.forEach(({oscillatorNode}) => {
+						oscillatorNode.stop(0);
+						oscillatorNode.disconnect();
+					});
+
+					resolve();
+				}, oscillators[0].noteDuration * 1000);
+			}
+		});
+	}
+
+	private getOscillatorNodesFromAccord(accord: CustomAccord) {
+		let gainNode: GainNode
+		let oscillatorNode: OscillatorNode
+
+		return accord.notes.map((note) => {
+			const noteDuration: number = note.duration * 0.18
+
+			gainNode = this.audioContext.createGain()
+			gainNode.connect(this.audioContext.destination)
+			gainNode.gain.setValueAtTime(0, this.audioContext.currentTime)
+			gainNode.gain.linearRampToValueAtTime(0.15, this.audioContext.currentTime + 0.01)
+			gainNode.gain.linearRampToValueAtTime(0, this.audioContext.currentTime + noteDuration - 0.01)
+
+			oscillatorNode = this.audioContext.createOscillator()
+			oscillatorNode.connect(gainNode)
+			oscillatorNode.connect(this.audioContext.destination)
+			oscillatorNode.type = this.oscillator
+			oscillatorNode.frequency.value = note.getPitch()
+
+			return { oscillatorNode, noteDuration }
 		})
 	}
 }

--- a/src/Partition.ts
+++ b/src/Partition.ts
@@ -1,18 +1,33 @@
 import {CustomAccord} from "./CustomAccord"
 
 class Partition {
+
+	/**
+	 * @param {CustomAccord[]} accords - The accords that will be played sequentially.
+	 * @param {OscillatorType} oscillator - The oscillator type that will be used to play the partition.
+	 * @param {AudioContext} audioContext - The audio context that will be used to play the partition.
+	 */
 	constructor(
 		public accords: CustomAccord[],
 		public oscillator: OscillatorType = 'sine',
 		public audioContext: AudioContext,
 	) {}
 
+	/**
+	 * Plays the partition sequentially.
+	 * @returns {Promise<void>}
+	 */
 	public async playPartition() {
 		for (const accord of this.accords) {
 			await this.playAccord(accord)
 		}
 	}
 
+	/**
+	 * Plays the accord simultaneously.
+	 * @returns {Promise<void>}
+	 * @param {CustomAccord} accord
+	 */
 	public async playAccord(accord: CustomAccord) {
 		return new Promise<void>((resolve) => {
 			let oscillators = this.getOscillatorNodesFromAccord(accord)


### PR DESCRIPTION
Refs #9 #3

As a reference for the docs later, a regular Partition can be created like this:

```js
const accord = new CustomAccord([
  new Note(NoteEnum['D'], 4, 1) // Accord with a single note
])
const accord2 = new CustomAccord([
  new Note(NoteEnum['D'], 5, 2),
  new Note(NoteEnum['D'], 5, 2) // Accord where two notes are played at once
])

const partition = new Partition([accord, accord, accord2], 'square', audioContext) // One accord can be called multiple times

partition.playPartition()
```

Additionally, I've added support for JSON Partitions (as I found it a bit tedious to create objects for longer melodies):

```js
  const partition = [
    [{note: 'D', octave: 4, duration: 1}],
    [{note: 'D', octave: 4, duration: 1}],
    [{note: 'D', octave: 5, duration: 2}],
    [{note: 'A', octave: 4, duration: 3}],
    [{note: 'GSharp', octave: 4, duration: 2}],
    [{note: 'G', octave: 4, duration: 2}],
    [{note: 'F', octave: 4, duration: 2}],
    [{note: 'D', octave: 4, duration: 1}],
    [{note: 'F', octave: 4, duration: 1}],
    [{note: 'G', octave: 4, duration: 1}],
];

const jsonPartition = new JSONPartition(jpartition, 'square', audioContext)

jsonPartition.playPartition()
```